### PR TITLE
DateFilter based on the wagtail-datepicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,21 @@ TextFilter(
 )
 ```
 
+#### DateFilter
+
+A datepicker using Wagtail's default picker.
+
+```python
+from admin_list_controls.filters import DateFilter
+
+DateFilter(
+    name='date',
+    label='Date',
+    format='%d/%m/%Y',
+    apply_to_queryset=lambda queryset, value: queryset.filter(date__gte=value),
+)
+```
+
 #### BooleanFilter
 
 A checkbox input.

--- a/admin_list_controls/src/admin_list_controls/components/filters/date.js
+++ b/admin_list_controls/src/admin_list_controls/components/filters/date.js
@@ -19,15 +19,28 @@ export function DateFilter({control}) {
     }
 
     useEffect(() => {
-            window.initDateChooser(input_id, {
-                "dayOfWeekStart": 1, "format": control.format,
-                onChangeDateTime(_, $el) {
-                    let el = $el.get(0);
-                    el.dispatchEvent(new Event('change'));
-                    inputChange({'target': el});
+        let start = null;
+        window.initDateChooser(input_id, {
+            "dayOfWeekStart": 1, "format": control.format,
+            onGenerate: function(current, input) {
+                start = start || current;
+                let picker = this[0];
+                if (start && !dateEqual(start, current)) {
+                    picker.querySelectorAll(
+                        '.xdsoft_datepicker .xdsoft_current:not(.xdsoft_today)'
+                    ).forEach(
+                        i => i.classList.remove("xdsoft_current")
+                    );
                 }
-            });
-        }, [input_id] // avoid init on every render
+            },
+            onChangeDateTime(current, $el) {
+                start = current;
+                let el = $el.get(0);
+                el.dispatchEvent(new Event('change'));
+                inputChange({'target': el});
+            }
+        });
+    }, [input_id] // avoid init on every render
     );
 
     return (

--- a/admin_list_controls/src/admin_list_controls/components/filters/date.js
+++ b/admin_list_controls/src/admin_list_controls/components/filters/date.js
@@ -1,0 +1,59 @@
+import React, {useState, useEffect} from "react";
+import {SET_VALUE} from '../../constants';
+import {store} from '../../state';
+import c from "classnames";
+import {submit_form} from "../../index";
+
+export function DateFilter({control}) {
+    const [value, set_value] = useState(control.value);
+
+    const input_id = `alc__filter-${control.component_id}-${control.name}`;
+    const inputChange = event => {
+        const value = event.target.value;
+        set_value(value);
+        store.dispatch({
+            type: SET_VALUE,
+            name: control.name,
+            value: value,
+        });
+    }
+
+    useEffect(() => {
+            window.initDateChooser(input_id, {
+                "dayOfWeekStart": 1, "format": control.format,
+                onChangeDateTime(_, $el) {
+                    let el = $el.get(0);
+                    el.dispatchEvent(new Event('change'));
+                    inputChange({'target': el});
+                }
+            });
+        }, [input_id] // avoid init on every render
+    );
+
+    return (
+        <div
+            className={c('alc__filter', 'alc__filter--text', control.extra_classes)}
+            style={control.style}
+        >
+            {/* A form element allows for keyboards to trigger submit events (enter keypress, etc) */}
+            <form onSubmit={event => {
+                event.preventDefault();
+                submit_form();
+            }}>
+                {control.label
+                    ? <label className="alc__filter__label" htmlFor={input_id}>{control.label}</label>
+                    : null
+                }
+                <div className="alc__filter__input-wrap">
+                    <input
+                        id={input_id}
+                        type="text"
+                        className="alc__filter__input"
+                        value={value}
+                        onChange={inputChange}
+                    />
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/admin_list_controls/src/admin_list_controls/components/root.js
+++ b/admin_list_controls/src/admin_list_controls/components/root.js
@@ -9,6 +9,7 @@ import {Divider} from "./divider";
 import {Block} from "./block";
 import {Selector} from "./selector";
 import {TextFilter} from "./filters/text";
+import {DateFilter} from "./filters/date";
 import {BooleanFilter} from "./filters/boolean";
 import {RadioFilter} from "./filters/radio";
 import {ChoiceFilter} from "./filters/choice";
@@ -56,6 +57,8 @@ export function render_control(control) {
                     return <RadioFilter key={control.component_id} control={control} />;
                 case 'choice':
                     return <ChoiceFilter key={control.component_id} control={control} />;
+                case 'date':
+                    return <DateFilter key={control.component_id} control={control} />;
                 default:
                     console.error('Unknown filter type', control.filter_type, control);
                     throw new Error(`Unknown filter type "${control.filter_type}`);

--- a/admin_list_controls/tests/test_filters.py
+++ b/admin_list_controls/tests/test_filters.py
@@ -1,7 +1,8 @@
+from datetime import date
 from django.test import RequestFactory
 from django_webtest import WebTest
 from admin_list_controls.filters import BaseFilter, TextFilter, BooleanFilter, ChoiceFilter, \
-    RadioFilter
+    RadioFilter, DateFilter
 from admin_list_controls.tests.utils import BaseTestCase
 
 
@@ -53,6 +54,18 @@ class TestFilters(BaseTestCase, WebTest):
         self.assertEqual(filter_.cleaned_value, '')
         filter_.handle_request(self.factory.get('/?test_name=test_value'))
         self.assertEqual(filter_.cleaned_value, 'test_value')
+
+    def test_date_filter_value(self):
+        filter_ = DateFilter(
+            name='test_name',
+            label='test_label',
+        )
+        filter_.handle_request(self.factory.get('/'))
+        self.assertEqual(filter_.cleaned_value, None)
+        filter_.handle_request(self.factory.get('/?test_name='))
+        self.assertEqual(filter_.cleaned_value, None)
+        filter_.handle_request(self.factory.get('/?test_name=2021-01-01'))
+        self.assertEqual(filter_.cleaned_value, date(2021, 1, 1))
 
     def test_boolean_filter_value(self):
         filter_ = BooleanFilter(

--- a/admin_list_controls/views.py
+++ b/admin_list_controls/views.py
@@ -2,9 +2,11 @@ import json
 import os
 from collections import Iterable
 
+from django import forms
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.safestring import mark_safe
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.contrib.modeladmin.views import IndexView
 from .components import ListControls
 from .selectors import LayoutSelector
@@ -159,6 +161,17 @@ class ListControlsIndexViewMixin:
             if hasattr(obj, 'derive_from_components'):
                 obj.derive_from_components(flattened_tree)
 
+    @property
+    def media(self):
+        js = self.model_admin.get_index_view_extra_js()
+        # @TODO only inject datechooser when needed
+        js += [versioned_static(
+            'wagtailadmin/js/date-time-chooser.js')]
+
+        return forms.Media(
+            css={'all': self.model_admin.get_index_view_extra_css()},
+            js=js
+        )
 
 class ListControlsIndexView(ListControlsIndexViewMixin, IndexView):
     pass

--- a/admin_list_controls/views.py
+++ b/admin_list_controls/views.py
@@ -1,8 +1,9 @@
-import os
 import json
+import os
 from collections import Iterable
 
 from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.safestring import mark_safe
 from wagtail.contrib.modeladmin.views import IndexView
 from .components import ListControls
@@ -84,7 +85,7 @@ class ListControlsIndexViewMixin:
             # Consumed by the front-end code to build the UI
             'initial_state': json.dumps({
                 'admin_list_controls': self.get_list_controls().serialize(),
-            }),
+            }, cls=DjangoJSONEncoder),
             'selected_layout_template': selected_layout_template,
             'widget_js': self.get_list_controls_widget_js(),
         }

--- a/test_project/shop/wagtail_hooks.py
+++ b/test_project/shop/wagtail_hooks.py
@@ -4,7 +4,6 @@ from admin_list_controls.components import Button, Icon, Text, Panel, Divider, B
     Columns, Summary
 from admin_list_controls.actions import TogglePanel, CollapsePanel, SubmitForm, Link
 from admin_list_controls.filters import TextFilter, ChoiceFilter, RadioFilter, BooleanFilter, DateFilter
-from wagtail.admin.staticfiles import versioned_static
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from .models import Product
 
@@ -112,6 +111,3 @@ class ProductAdmin(ModelAdmin):
     model = Product
     index_view_class = IndexView
     search_fields = ('name',)
-
-    index_view_extra_js = [versioned_static(
-        'wagtailadmin/js/date-time-chooser.js')]

--- a/test_project/shop/wagtail_hooks.py
+++ b/test_project/shop/wagtail_hooks.py
@@ -1,10 +1,11 @@
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from admin_list_controls.selectors import LayoutSelector
 from admin_list_controls.views import ListControlsIndexView
 from admin_list_controls.components import Button, Icon, Text, Panel, Divider, Block, Spacer, \
     Columns, Summary
 from admin_list_controls.actions import TogglePanel, CollapsePanel, SubmitForm, Link
-from admin_list_controls.filters import TextFilter, ChoiceFilter, RadioFilter, BooleanFilter
+from admin_list_controls.filters import TextFilter, ChoiceFilter, RadioFilter, BooleanFilter, DateFilter
+from wagtail.admin.staticfiles import versioned_static
+from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from .models import Product
 
 
@@ -94,6 +95,13 @@ class IndexView(ListControlsIndexView):
             Panel(ref='panel_2', collapsed=True)(
                 Text('medium text ', size=Text.MEDIUM),
                 Text('large text', size=Text.LARGE),
+                DateFilter(
+                    name='date_start',
+                    label='Date',
+                    format='%d/%m/%Y',
+                ),
+                Spacer(),
+                Button(action=SubmitForm())('Apply filters'),
             ),
             Summary(),
         ]
@@ -104,3 +112,6 @@ class ProductAdmin(ModelAdmin):
     model = Product
     index_view_class = IndexView
     search_fields = ('name',)
+
+    index_view_extra_js = [versioned_static(
+        'wagtailadmin/js/date-time-chooser.js')]


### PR DESCRIPTION
I created a DateFilter using Wagtail's datepicker implementation.

### Backend code
Backend code works like the django/wagtail form fields and widgets. Its uses mostly the same code to parse and output dates from strings and vice versa.
Beware: `date-time-chooser.js` is always injected into `media` of the view, but I didn't saw any harm in doing that. 

### Frontend code
Frontend is a bit messy (see: `useEffect` hook in `components/filters/date.js`), because there seems to be an error in wagtail's `onGenerate` function. It breaks with a custom date format. I replicated the functionality and it seems to works fine. But you never know ... Ye old ~3000 line `jquery.datetimepicker.js` is a bit intimidating :) 